### PR TITLE
feature: highlight current train when viewing station arrivals

### DIFF
--- a/src/views/trains.rs
+++ b/src/views/trains.rs
@@ -15,6 +15,7 @@ pub struct TrainsStationResponse {
     pub station_name: String,
     pub arrivals: Vec<crate::services::marta::TrainArrival>,
     pub is_starred: bool,
+    pub train_id: String,
 }
 
 #[derive(Template)]

--- a/templates/trains/show.html.askama
+++ b/templates/trains/show.html.askama
@@ -8,7 +8,9 @@
     <div class="flex justify-end border-r-2 border-black dark:border-white">
       <ul class="p-4 text-right">
         {% for arrival in arrivals %}
-          <li class="capitalize my-6">{{arrival.station_name()}}</li>
+          <li class="capitalize my-6">
+            <a href="/stations/{{arrival.station_name()}} station?from={{train_id}}">{{arrival.station_name()}}</a>
+          </li>
         {% endfor %}
       </ul>
     </div>

--- a/templates/trains/station.html.askama
+++ b/templates/trains/station.html.askama
@@ -1,7 +1,7 @@
 {% extends "layout.html.askama" %}
 
 {% block content %}
-<div id="station-view" hx-get="/stations/{{station_name}}" hx-swap="morph" hx-trigger="every 10s">
+<div id="station-view" hx-get="/stations/{{station_name}}?from={{train_id}}" hx-swap="morph" hx-trigger="every 10s">
   <h1 class="border-b dark:border-zinc-600 text-xl font-bold px-2 py-4 capitalize">
     {% if is_starred %}
     <span class="mb-2 mr-2 ">
@@ -28,7 +28,7 @@
   {% endif %}
   {% for arrival in arrivals %}
     <li>
-      <a href="/trains/{{arrival.train_id}}" class="{% include "_list_link_style.html.askama" %}">
+      <a href="/trains/{{arrival.train_id}}" class="{% include "_list_link_style.html.askama" %} {%if arrival.train_id == train_id %}bg-green-300{% endif %}">
         <div class="flex flex-wrap justify-end gap-2 gap-y-4">
           <div class="flex">
             <span class="font-mono border-r {{arrival.train_color()}} dark:text-zinc-800 text-white font-black text-xl rounded-l-full p-2 pl-4">{{ arrival.direction }}</span>


### PR DESCRIPTION
When you're on a train, and you click into the train view, you can see when your train will arrive at a given station.

If you need to transfer, you often will want to view that station to see when the train you need to catch will arrive.

This makes that workflow a bit easier with two changes:

1. makes it possible to tap on a station name in the "train arrivals" view to go to a station
2. when you do that, pass the current train ID to the next view, allowing the UI to highlight your train in the list of arrivals.

This PR is missing some styles which I leave up to the benevolent marta.io dictator to decide:

1. do the station names in the train arrival time list need to indicate they are links somehow?
2. what should the UI indicator be for 'this is the train you are on' in the station view?   Right now it's an ugly placeholder green color:
![image](https://github.com/jakswa/roundhouse/assets/805358/30f7d933-8f1f-4562-a454-2384e1e77769)


